### PR TITLE
Add 'all' optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
-    "setuptools>=61.0"
+    "setuptools>=61.0",
+    "pip>=22.0"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -25,6 +26,7 @@ issue_tracker = "https://github.com/ahaim5357/project-patcher/issues"
 
 [project.optional-dependencies]
 git = ["GitPython>=3.1"]
+all = ["project_patcher[git]"]
 
 [tools.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "project_patcher"
-version = "0.2.0.dev0"
+version = "0.2.0.dev1"
 authors = [
     { name = "Aaron Haim", email = "ahaim@ashwork.net" }
 ]


### PR DESCRIPTION
Closes #5

Adds 'all' to download all optional dependencies used by project-patcher. Since this is using recursive dependencies, pip 22 is required.