### PR TITLE
Disable handling dotfiles by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "project_patcher"
-version = "0.2.0.dev1"
+version = "0.2.0.dev2"
 authors = [
     { name = "Aaron Haim", email = "ahaim@ashwork.net" }
 ]

--- a/src/project_patcher/cli.py
+++ b/src/project_patcher/cli.py
@@ -23,9 +23,14 @@ def main() -> None:
     '--import_metadata', '-I',
     type = str,
     default = None,
-    help = "A path or URL to the metadata JSON."
+    help = 'A path or URL to the metadata JSON.'
 )
-def init(import_metadata: Optional[str] = None) -> None:
+@click.option(
+    '-a', '-A', 'include_hidden',
+    is_flag = True,
+    help = 'When added, copies hidden files to the working directory.'
+)
+def init(import_metadata: Optional[str] = None, include_hidden: bool = False) -> None:
     """Initializes a new project or an existing project from the
     metadata JSON in the executing directory, an import, or from
     the metadata builder if neither are present.
@@ -36,7 +41,7 @@ def init(import_metadata: Optional[str] = None) -> None:
 
     # Setup workspace
     wspc.setup_clean(metadata)
-    wspc.setup_working()
+    wspc.setup_working(include_hidden = include_hidden)
 
     print('Success!')
 

--- a/src/project_patcher/workspace/project.py
+++ b/src/project_patcher/workspace/project.py
@@ -183,7 +183,7 @@ def apply_patches(working_dir: str = '_src', patch_dir: str = '_patches') -> boo
     return True
 
 def setup_working(clean_dir: str = '_clean', working_dir: str = '_src',
-        patch_dir: str = '_patches', out_dir: str = '_out') -> bool:
+        patch_dir: str = '_patches', out_dir: str = '_out', include_hidden: bool = False) -> bool:
     """Generates a working directory from the project metadata and any additional
     files and patches.
 
@@ -212,7 +212,11 @@ def setup_working(clean_dir: str = '_clean', working_dir: str = '_src',
     os.makedirs(working_dir)
 
     # Copy clean directory into working directory (clean directory must exist)
-    shutil.copytree(clean_dir, working_dir, dirs_exist_ok = True)
+    if include_hidden:
+        shutil.copytree(clean_dir, working_dir, dirs_exist_ok = True)
+    else:
+        shutil.copytree(clean_dir, working_dir, dirs_exist_ok = True,
+            ignore = shutil.ignore_patterns('.*'))
 
     # If an output directory exists, copy into working directory
     if os.path.exists(out_dir) and os.path.isdir(out_dir):


### PR DESCRIPTION
Closes #3

Disables importing dotfiles into the working directory on construction. Dotfiles created in the working directory will still be copied over on output.