### PR TITLE
[Feature] Add ignore and overwrite permissions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "project_patcher"
-version = "0.2.0.dev2"
+version = "0.2.0.dev3"
 authors = [
     { name = "Aaron Haim", email = "ahaim@ashwork.net" }
 ]

--- a/src/project_patcher/cli.py
+++ b/src/project_patcher/cli.py
@@ -50,7 +50,10 @@ def output() -> None:
     """Generates any patches and clones the new files to an output
     directory."""
 
+    # Get metadata
+    metadata: ProjectMetadata = wspc.read_metadata()
+
     # Output working and generate patches
-    wspc.output_working()
+    wspc.output_working(metadata)
 
     print('Success!')

--- a/src/project_patcher/metadata/base.py
+++ b/src/project_patcher/metadata/base.py
@@ -1,22 +1,33 @@
 """A script containing information about handling the project metadata.
 """
 
-from typing import List
+import os
+from typing import List, Optional, Tuple, Set
+from pathlib import Path
+import fnmatch
 from project_patcher.lazy import SINGLETON
 from project_patcher.metadata.file import ProjectFile
 from project_patcher.struct.codec import DictCodec, DictObject
+from project_patcher.utils import get_or_default
 
 class ProjectMetadata:
     """Metadata information associated with the project being patched or ran."""
 
-    def __init__(self, files: List[ProjectFile]) -> None:
+    def __init__(self, files: List[ProjectFile],
+            ignore: Optional[List[str]] = None, overwrite: Optional[List[str]] = None) -> None:
         """
         Parameters
         ----------
         files : list of `ProjectFile`s
-            The files associated with the project. 
+            The files associated with the project.
+        ignore : list of str
+            The patterns for files that are ignored for patching.
+        overwrite: list of str
+            The patterns for files that are overwritten instead of patching.
         """
         self.files: List[ProjectFile] = files
+        self.ignore: List[str] = [] if ignore is None else ignore
+        self.overwrite: List[str] = [] if overwrite is None else overwrite
 
     def setup(self, root_dir: str) -> bool:
         """Sets up the project for usage.
@@ -44,6 +55,36 @@ class ProjectMetadata:
         """
         return SINGLETON.METADATA_CODEC
 
+    def ignore_and_overwrite(self, root_dir: str) -> Tuple[Set[str], Set[str]]:
+        """Gets the ignored and overwritten files from the specified directory.
+
+        Parameters
+        ----------
+        root_dir : str
+            The root directory to get the files of.
+        
+        Returns
+        -------
+        (set of strs, set of strs)
+            A tuple of ignored and overwritten files, respectively.
+        """
+
+        # Get all files
+        files: list[str] = [Path(os.path.relpath(path, root_dir)).as_posix() \
+            for path in Path(root_dir).rglob('*') if path.is_file()]
+
+        # Get ignored files
+        ignored_files: Set[str] = set()
+        for ignore in self.ignore: # type: str
+            ignored_files.update(fnmatch.filter(files, ignore))
+
+        # Get overwritten files
+        overwritten_files: Set[str] = set()
+        for overwrite in self.overwrite: # type: str
+            overwritten_files.update(fnmatch.filter(files, overwrite))
+
+        return (ignored_files, overwritten_files)
+
 def build_metadata() -> ProjectMetadata:
     """Builds a ProjectMetadata from user input.
     
@@ -52,14 +93,32 @@ def build_metadata() -> ProjectMetadata:
     ProjectMetadata
         The built project metadata.
     """
+
+    # Project Files
     available_file_types: str = ', '.join(SINGLETON.PROJECT_FILE_BUILDERS.keys())
     files: List[ProjectFile] = []
-    get_file: bool = True
-    while get_file:
+    flag: bool = True
+    while flag:
         file_type: str = input(f"Add file ({available_file_types}): ").lower()
         files.append(SINGLETON.PROJECT_FILE_BUILDERS[file_type]())
-        get_file = input('Would you like to add another file? ').lower()[0] != 'n'
-    return ProjectMetadata(files)
+        flag = input('Would you like to add another file (y/n)? ').lower()[0] != 'n'
+
+    # Ignore Patterns
+    flag = input('Would you like to ignore any files when patching (y/n)? ').lower()[0] != 'n'
+    ignore: List[str] = []
+    while flag:
+        ignore.append(input('Add pattern to ignore: '))
+        flag = input('Would you like to ignore another pattern (y/n)? ').lower()[0] != 'n'
+
+    # Overwrite Patterns
+    flag = input('Would you like to overwrite any files when patching (y/n)? ').lower()[0] != 'n'
+    overwrite: List[str] = []
+    while flag:
+        overwrite.append(input('Add pattern to overwrite: '))
+        flag = input('Would you like to overwrite another pattern (y/n)? ').lower()[0] != 'n'
+
+    # Create metadata
+    return ProjectMetadata(files, ignore = ignore, overwrite = overwrite)
 
 class ProjectMetadataCodec(DictCodec[ProjectMetadata]):
     """A codec for encoding and decoding a ProjectMetadata.
@@ -68,6 +127,8 @@ class ProjectMetadataCodec(DictCodec[ProjectMetadata]):
     def encode(self, obj: ProjectMetadata) -> DictObject:
         dict_obj: DictObject = {}
         dict_obj['files'] = list(map(lambda file: file.codec().encode(file), obj.files))
+        dict_obj['ignore'] = obj.ignore
+        dict_obj['overwrite'] = obj.overwrite
         return dict_obj
 
     def __decode_file(self, file: DictObject) -> ProjectFile:
@@ -86,4 +147,6 @@ class ProjectMetadataCodec(DictCodec[ProjectMetadata]):
         return SINGLETON.PROJECT_FILE_TYPES[file['type']].decode(file)
 
     def decode(self, obj: DictObject) -> ProjectMetadata:
-        return ProjectMetadata(list(map(self.__decode_file, obj['files'])))
+        return ProjectMetadata(list(map(self.__decode_file, obj['files'])),
+            ignore = get_or_default(obj, 'ignore', ProjectMetadata),
+            overwrite = get_or_default(obj, 'overwrite', ProjectMetadata))


### PR DESCRIPTION
Closes #2 

Adds the ability to allow files to be patched to either be ignored or overwritten. Syntax uses pattern matching via fnmatch.